### PR TITLE
Implement minCost function for fruit rearrangement

### DIFF
--- a/2561. Rearranging Fruits.cpp
+++ b/2561. Rearranging Fruits.cpp
@@ -1,0 +1,32 @@
+
+class Solution {
+public:
+    long long minCost(vector<int>& basket1, vector<int>& basket2) {
+        unordered_map<int,int> freq;
+        for (int x : basket1) freq[x]++;
+        for (int x : basket2) freq[x]--;
+
+        vector<int> extra1, extra2;
+        int minFruit = INT_MAX;
+
+        // Collect unbalanced fruits
+        for (auto [fruit, diff] : freq) {
+            minFruit = min(minFruit, fruit);
+            if (diff % 2 != 0) return -1; // impossible to balance
+            int count = abs(diff) / 2;
+            if (diff > 0) while (count--) extra1.push_back(fruit);
+            else while (count--) extra2.push_back(fruit);
+        }
+
+        sort(extra1.begin(), extra1.end());
+        sort(extra2.rbegin(), extra2.rend());
+
+        long long cost = 0;
+        for (int i = 0; i < extra1.size(); ++i) {
+            cost += min((long long)min(extra1[i], extra2[i]), 2LL * minFruit);
+        }
+        return cost;
+    }
+};
+
+    


### PR DESCRIPTION
###  **Intuition**
Each fruit variety must occur the same number of times in both baskets combined in order for them to be equal.
It must be switched to the other fruit variety if more of one type is found in one basket.

Either a direct swap or an intermediate swap using the smallest fruit type can be used to cut costs.
The idea of greed:

Whether it's direct or double the smallest fruit value (cheapest indirect swap), always pick the lowest cost to balance the baskets.



### **Approach**

- Count the frequency of each fruit type in both baskets.
- If any fruit’s total count is odd, return -1 (impossible to balance).
- Find which fruits are extra in each basket (difference divided by 2).
- Sort these extra fruits — one ascending, one descending — to minimize cost.
- For each mismatched pair, take the minimum of:
- direct swap cost (min(a, b)), and
- indirect swap using the smallest fruit value (2 * minFruit).